### PR TITLE
Allows Package Control to know windows only

### DIFF
--- a/package.json
+++ b/package.json
@@ -9,6 +9,7 @@
 			"readme": "https://raw.githubusercontent.com/thecotne/smart_less_build/master/README.md",
 			"releases": [
 				{
+					"platforms": "windows",
 					"sublime_text": "*",
 					"details": "https://github.com/thecotne/smart_less_build/tags"
 				}


### PR DESCRIPTION
The readme states this package is for windows only but the package.json file shows otherwise. Updates so that the package.json file states that this is a windows only package.
